### PR TITLE
Renaming for a less verbose API; hooking up a missed option

### DIFF
--- a/GuardianClient/GuardianClient.Tests/GetItemAsyncTests.cs
+++ b/GuardianClient/GuardianClient.Tests/GetItemAsyncTests.cs
@@ -10,27 +10,27 @@ public class GetItemAsyncTests : TestBase
     public async Task GetItemAsync_WithValidId_ReturnsItem()
     {
         // First get a valid item ID from search
-        var searchResult = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var searchResult = await Client.SearchAsync(new SearchOptions
         {
             Query = "technology",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 1 }
+            PageOptions = new PageOptions { PageSize = 1 }
         });
-        searchResult.ShouldNotBeNull("Search should return results");
-        searchResult.Results.Count.ShouldBe(1, "Should return exactly one result");
+        searchResult.ShouldNotBeNull();
+        searchResult.Results.Count.ShouldBe(1);
 
         var contentItem = searchResult.Results.First();
         var itemId = contentItem.Id;
 
         // Now get the specific item
-        var singleItemResult = await ApiClient.GetItemAsync(itemId,
-            new GuardianApiContentAdditionalInformationOptions { ShowFields = [GuardianApiContentShowFieldsOption.Body] });
+        var singleItemResult = await Client.GetItemAsync(itemId,
+            new AdditionalInformationOptions { ShowFields = [ContentField.Body] });
 
-        singleItemResult.ShouldNotBeNull("GetItem result should not be null");
-        singleItemResult.Status.ShouldBe("ok", "API response status should be 'ok'");
-        singleItemResult.Content.ShouldNotBeNull("Content should not be null");
-        singleItemResult.Content.Id.ShouldBe(itemId, "Returned content ID should match requested ID");
-        singleItemResult.Content.WebTitle.ShouldNotBeNullOrEmpty("Content should have a title");
-        singleItemResult.Content.Fields.ShouldNotBeNull("Fields should be populated when ShowFields is specified");
+        singleItemResult.ShouldNotBeNull();
+        singleItemResult.Status.ShouldBe("ok");
+        singleItemResult.Content.ShouldNotBeNull();
+        singleItemResult.Content.Id.ShouldBe(itemId);
+        singleItemResult.Content.WebTitle.ShouldNotBeNullOrEmpty();
+        singleItemResult.Content.Fields.ShouldNotBeNull();
 
         Console.WriteLine($"Retrieved item: {singleItemResult.Content.WebTitle}");
         Console.WriteLine($"Item ID: {singleItemResult.Content.Id}");
@@ -51,7 +51,7 @@ public class GetItemAsyncTests : TestBase
 
         var exception = await Should.ThrowAsync<HttpRequestException>(async () =>
         {
-            await ApiClient.GetItemAsync(invalidId);
+            await Client.GetItemAsync(invalidId);
         });
 
         Console.WriteLine($"Expected exception for invalid ID: {exception.Message}");
@@ -62,7 +62,7 @@ public class GetItemAsyncTests : TestBase
     {
         var exception = await Should.ThrowAsync<ArgumentException>(async () =>
         {
-            await ApiClient.GetItemAsync(null!);
+            await Client.GetItemAsync(null!);
         });
 
         Console.WriteLine($"Expected exception for null ID: {exception.Message}");
@@ -73,7 +73,7 @@ public class GetItemAsyncTests : TestBase
     {
         var exception = await Should.ThrowAsync<ArgumentException>(async () =>
         {
-            await ApiClient.GetItemAsync("");
+            await Client.GetItemAsync("");
         });
 
         Console.WriteLine($"Expected exception for empty ID: {exception.Message}");
@@ -83,30 +83,30 @@ public class GetItemAsyncTests : TestBase
     public async Task GetItemAsync_WithShowFields_ReturnsEnhancedContent()
     {
         // Get a valid item ID
-        var searchResult = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var searchResult = await Client.SearchAsync(new SearchOptions
         {
             Query = "politics",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 1 }
+            PageOptions = new PageOptions { PageSize = 1 }
         });
 
         var itemId = searchResult.Results.First().Id;
 
         // Request with multiple fields
-        var result = await ApiClient.GetItemAsync(itemId,
-            new GuardianApiContentAdditionalInformationOptions
+        var result = await Client.GetItemAsync(itemId,
+            new AdditionalInformationOptions
             {
                 ShowFields =
                 [
-                    GuardianApiContentShowFieldsOption.Headline,
-                    GuardianApiContentShowFieldsOption.Body,
-                    GuardianApiContentShowFieldsOption.Byline,
-                    GuardianApiContentShowFieldsOption.Thumbnail
+                    ContentField.Headline,
+                    ContentField.Body,
+                    ContentField.Byline,
+                    ContentField.Thumbnail
                 ]
             });
 
         result.ShouldNotBeNull();
-        result.Content.Fields.ShouldNotBeNull("Fields should be populated");
-        result.Content.Fields.Headline.ShouldNotBeNullOrEmpty("Headline should be populated");
+        result.Content.Fields.ShouldNotBeNull();
+        result.Content.Fields.Headline.ShouldNotBeNullOrEmpty();
 
         Console.WriteLine($"Enhanced content for: {result.Content.WebTitle}");
         Console.WriteLine($"Headline: {result.Content.Fields.Headline}");
@@ -118,24 +118,24 @@ public class GetItemAsyncTests : TestBase
     public async Task GetItemAsync_WithShowTags_ReturnsContentWithTags()
     {
         // Get a valid item ID
-        var searchResult = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var searchResult = await Client.SearchAsync(new SearchOptions
         {
             Query = "sport",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 1 }
+            PageOptions = new PageOptions { PageSize = 1 }
         });
 
         var itemId = searchResult.Results.First().Id;
 
         // Request with tags
-        var result = await ApiClient.GetItemAsync(itemId,
-            new GuardianApiContentAdditionalInformationOptions
+        var result = await Client.GetItemAsync(itemId,
+            new AdditionalInformationOptions
             {
-                ShowTags = [GuardianApiContentShowTagsOption.Keyword, GuardianApiContentShowTagsOption.Tone, GuardianApiContentShowTagsOption.Type]
+                ShowTags = [ContentTag.Keyword, ContentTag.Tone, ContentTag.Type]
             });
 
         result.ShouldNotBeNull();
-        result.Content.Tags.ShouldNotBeNull("Tags should be populated");
-        result.Content.Tags.Count.ShouldBeGreaterThan(0, "Should have at least one tag");
+        result.Content.Tags.ShouldNotBeNull();
+        result.Content.Tags.Count.ShouldBeGreaterThan(0);
 
         Console.WriteLine($"Content '{result.Content.WebTitle}' has {result.Content.Tags.Count} tags:");
         foreach (var tag in result.Content.Tags.Take(5)) // Show first 5 tags
@@ -148,19 +148,19 @@ public class GetItemAsyncTests : TestBase
     public async Task GetItemAsync_WithShowElements_ReturnsContentWithElements()
     {
         // Get a valid item ID
-        var searchResult = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var searchResult = await Client.SearchAsync(new SearchOptions
         {
             Query = "music",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 1 }
+            PageOptions = new PageOptions { PageSize = 1 }
         });
 
         var itemId = searchResult.Results.First().Id;
 
         // Request with elements
-        var result = await ApiClient.GetItemAsync(itemId,
-            new GuardianApiContentAdditionalInformationOptions
+        var result = await Client.GetItemAsync(itemId,
+            new AdditionalInformationOptions
             {
-                ShowElements = [GuardianApiContentShowElementsOption.Image, GuardianApiContentShowElementsOption.Video]
+                ShowElements = [ContentElement.Image, ContentElement.Video]
             });
 
         result.ShouldNotBeNull();
@@ -181,17 +181,17 @@ public class GetItemAsyncTests : TestBase
     public async Task GetItemAsync_WithShowBlocks_ReturnsContentWithBlocks()
     {
         // Get a valid item ID
-        var searchResult = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var searchResult = await Client.SearchAsync(new SearchOptions
         {
             Query = "news",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 1 }
+            PageOptions = new PageOptions { PageSize = 1 }
         });
 
         var itemId = searchResult.Results.First().Id;
 
         // Request with blocks using string array (as it's still string-based)
-        var result = await ApiClient.GetItemAsync(itemId,
-            new GuardianApiContentAdditionalInformationOptions
+        var result = await Client.GetItemAsync(itemId,
+            new AdditionalInformationOptions
             {
                 ShowBlocks = ["main", "body"]
             });
@@ -214,27 +214,27 @@ public class GetItemAsyncTests : TestBase
     public async Task GetItemAsync_WithAllOptions_ReturnsFullyEnhancedContent()
     {
         // Get a valid item ID
-        var searchResult = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var searchResult = await Client.SearchAsync(new SearchOptions
         {
             Query = "culture",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 1 }
+            PageOptions = new PageOptions { PageSize = 1 }
         });
 
         var itemId = searchResult.Results.First().Id;
 
         // Request with all enhancement options
-        var result = await ApiClient.GetItemAsync(itemId,
-            new GuardianApiContentAdditionalInformationOptions
+        var result = await Client.GetItemAsync(itemId,
+            new AdditionalInformationOptions
             {
-                ShowFields = [GuardianApiContentShowFieldsOption.All],
-                ShowTags = [GuardianApiContentShowTagsOption.All],
-                ShowElements = [GuardianApiContentShowElementsOption.All],
+                ShowFields = [ContentField.All],
+                ShowTags = [ContentTag.All],
+                ShowElements = [ContentElement.All],
                 ShowBlocks = ["all"]
             });
 
         result.ShouldNotBeNull();
-        result.Content.Fields.ShouldNotBeNull("All fields should be populated");
-        result.Content.Tags.ShouldNotBeNull("All tags should be populated");
+        result.Content.Fields.ShouldNotBeNull();
+        result.Content.Tags.ShouldNotBeNull();
 
         Console.WriteLine($"Fully enhanced content: {result.Content.WebTitle}");
         Console.WriteLine($"  Fields populated: Yes");

--- a/GuardianClient/GuardianClient.Tests/GuardianApiClientIntegrationTests.cs
+++ b/GuardianClient/GuardianClient.Tests/GuardianApiClientIntegrationTests.cs
@@ -9,41 +9,41 @@ public class GuardianApiClientIntegrationTests : TestBase
     [TestMethod]
     public void ApiClient_ShouldNotBeNull()
     {
-        ApiClient.ShouldNotBeNull("API client should be properly initialized");
-        ApiClient.ShouldBeAssignableTo<IGuardianApiClient>("API client should implement the interface");
+        Client.ShouldNotBeNull();
+        Client.ShouldBeAssignableTo<IGuardianApiClient>();
     }
 
     [TestMethod]
     public async Task EndToEnd_SearchAndGetItem_WorksTogether()
     {
         // Search for content
-        var searchResult = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var searchResult = await Client.SearchAsync(new SearchOptions
         {
             Query = "artificial intelligence",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 1 },
-            FilterOptions = new GuardianApiContentFilterOptions
+            PageOptions = new PageOptions { PageSize = 1 },
+            FilterOptions = new FilterOptions
             {
                 Section = "technology"
             }
         });
 
-        searchResult.ShouldNotBeNull("Search should return results");
-        searchResult.Results.Count.ShouldBe(1, "Should return exactly one result");
+        searchResult.ShouldNotBeNull();
+        searchResult.Results.Count.ShouldBe(1);
 
         // Get the specific item with enhanced information
         var contentItem = searchResult.Results.First();
-        var detailedResult = await ApiClient.GetItemAsync(contentItem.Id,
-            new GuardianApiContentAdditionalInformationOptions
+        var detailedResult = await Client.GetItemAsync(contentItem.Id,
+            new AdditionalInformationOptions
             {
-                ShowFields = [GuardianApiContentShowFieldsOption.Headline, GuardianApiContentShowFieldsOption.Body],
-                ShowTags = [GuardianApiContentShowTagsOption.Keyword]
+                ShowFields = [ContentField.Headline, ContentField.Body],
+                ShowTags = [ContentTag.Keyword]
             });
 
-        detailedResult.ShouldNotBeNull("Detailed result should not be null");
-        detailedResult.Content!.Id.ShouldBe(contentItem.Id, "IDs should match");
-        detailedResult.Content.WebTitle.ShouldBe(contentItem.WebTitle, "Titles should match");
-        detailedResult.Content.Fields.ShouldNotBeNull("Detailed fields should be populated");
-        detailedResult.Content.Tags.ShouldNotBeNull("Tags should be populated");
+        detailedResult.ShouldNotBeNull();
+        detailedResult.Content!.Id.ShouldBe(contentItem.Id);
+        detailedResult.Content.WebTitle.ShouldBe(contentItem.WebTitle);
+        detailedResult.Content.Fields.ShouldNotBeNull();
+        detailedResult.Content.Tags.ShouldNotBeNull();
 
         Console.WriteLine("=== END-TO-END TEST RESULTS ===");
         Console.WriteLine();
@@ -53,12 +53,12 @@ public class GuardianApiClientIntegrationTests : TestBase
         Console.WriteLine($"  Published: {contentItem.WebPublicationDate}");
         Console.WriteLine($"  URL: {contentItem.WebUrl}");
         Console.WriteLine();
-        
+
         Console.WriteLine($"DETAILED CONTENT:");
         Console.WriteLine($"  ID: {detailedResult.Content.Id}");
         Console.WriteLine($"  Headline: {detailedResult.Content.Fields.Headline ?? "N/A"}");
         Console.WriteLine($"  Tags: {detailedResult.Content.Tags.Count} tags");
-        
+
         if (detailedResult.Content.Tags.Any())
         {
             Console.WriteLine($"  Tag List:");
@@ -66,12 +66,13 @@ public class GuardianApiClientIntegrationTests : TestBase
             {
                 Console.WriteLine($"    - {tag.WebTitle} ({tag.Type})");
             }
+
             if (detailedResult.Content.Tags.Count > 10)
             {
                 Console.WriteLine($"    ... and {detailedResult.Content.Tags.Count - 10} more tags");
             }
         }
-        
+
         Console.WriteLine();
         Console.WriteLine($"FULL ARTICLE BODY:");
         Console.WriteLine("==================");
@@ -83,6 +84,7 @@ public class GuardianApiClientIntegrationTests : TestBase
         {
             Console.WriteLine("No body content available");
         }
+
         Console.WriteLine("==================");
         Console.WriteLine();
     }
@@ -91,44 +93,44 @@ public class GuardianApiClientIntegrationTests : TestBase
     public async Task SearchWithComplexOptions_ReturnsExpectedResults()
     {
         // Test a complex search with multiple option types
-        var result = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var result = await Client.SearchAsync(new SearchOptions
         {
             Query = "climate change",
             QueryFields = ["body", "headline"],
-            FilterOptions = new GuardianApiContentFilterOptions
+            FilterOptions = new FilterOptions
             {
                 Section = "environment"
             },
-            DateOptions = new GuardianApiContentDateOptions
+            DateOptions = new DateOptions
             {
                 FromDate = new DateOnly(2023, 1, 1)
             },
-            PageOptions = new GuardianApiContentPageOptions
+            PageOptions = new PageOptions
             {
                 Page = 1,
                 PageSize = 5
             },
-            OrderOptions = new GuardianApiContentOrderOptions
+            OrderOptions = new OrderOptions
             {
-                OrderBy = GuardianApiContentOrderBy.Relevance
+                OrderBy = ContentOrder.Relevance
             },
-            AdditionalInformationOptions = new GuardianApiContentAdditionalInformationOptions
+            AdditionalInformationOptions = new AdditionalInformationOptions
             {
-                ShowFields = [GuardianApiContentShowFieldsOption.Headline, GuardianApiContentShowFieldsOption.Score],
-                ShowTags = [GuardianApiContentShowTagsOption.Tone]
+                ShowFields = [ContentField.Headline, ContentField.Score],
+                ShowTags = [ContentTag.Tone]
             }
         });
 
-        result.ShouldNotBeNull("Complex search should return results");
-        result.Status.ShouldBe("ok", "API should respond successfully");
-        result.Results.Count.ShouldBeLessThanOrEqualTo(5, "Should respect page size");
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe("ok");
+        result.Results.Count.ShouldBeLessThanOrEqualTo(5);
 
         // Verify enhanced data is present
         if (result.Results.Any())
         {
             var firstItem = result.Results.First();
-            firstItem.Fields.ShouldNotBeNull("Enhanced fields should be present");
-            firstItem.Tags.ShouldNotBeNull("Tags should be present");
+            firstItem.Fields.ShouldNotBeNull();
+            firstItem.Tags.ShouldNotBeNull();
 
             Console.WriteLine($"Complex search returned {result.Results.Count} results");
             Console.WriteLine($"First result: {firstItem.WebTitle}");
@@ -140,25 +142,25 @@ public class GuardianApiClientIntegrationTests : TestBase
     public async Task TypeSafetyTest_EnumsMapToCorrectApiValues()
     {
         // This test ensures our enums map to the correct API values
-        var result = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var result = await Client.SearchAsync(new SearchOptions
         {
             Query = "test",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 1 },
-            AdditionalInformationOptions = new GuardianApiContentAdditionalInformationOptions
+            PageOptions = new PageOptions { PageSize = 1 },
+            AdditionalInformationOptions = new AdditionalInformationOptions
             {
                 ShowFields =
                 [
-                    GuardianApiContentShowFieldsOption.Headline,
-                    GuardianApiContentShowFieldsOption.TrailText,
-                    GuardianApiContentShowFieldsOption.ShowInRelatedContent
+                    ContentField.Headline,
+                    ContentField.TrailText,
+                    ContentField.ShowInRelatedContent
                 ],
-                ShowTags = [GuardianApiContentShowTagsOption.Tone, GuardianApiContentShowTagsOption.Type],
-                ShowElements = [GuardianApiContentShowElementsOption.Image]
+                ShowTags = [ContentTag.Tone, ContentTag.Type],
+                ShowElements = [ContentElement.Image]
             }
         });
 
-        result.ShouldNotBeNull("Type safety test should work");
-        result.Status.ShouldBe("ok", "API should accept enum-mapped values");
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe("ok");
 
         if (result.Results.Any())
         {
@@ -168,5 +170,17 @@ public class GuardianApiClientIntegrationTests : TestBase
             Console.WriteLine($"  Tags populated: {item.Tags != null}");
             Console.WriteLine($"  Elements populated: {item.Elements != null}");
         }
+    }
+
+    [TestMethod]
+    public async Task SimpleSearch()
+    {
+        var result = await Client.SearchAsync(new SearchOptions
+        {
+            AdditionalInformationOptions = new AdditionalInformationOptions
+            {
+                ShowFields = [ContentField.Body]
+            }
+        });
     }
 }

--- a/GuardianClient/GuardianClient.Tests/GuardianApiClientIntegrationTests.cs
+++ b/GuardianClient/GuardianClient.Tests/GuardianApiClientIntegrationTests.cs
@@ -179,8 +179,18 @@ public class GuardianApiClientIntegrationTests : TestBase
         {
             AdditionalInformationOptions = new AdditionalInformationOptions
             {
-                ShowFields = [ContentField.Body]
+                ShowFields = [ContentField.Body],
+                ShowElements = [ContentElement.Image]
+            },
+            PageOptions = new PageOptions
+            {
+                Page = 0,
+                PageSize = 10
             }
         });
+
+        var body = result?.Results.First(r => r.Type == "article").Fields?.Body;
+
+        body.ShouldNotBeNull();
     }
 }

--- a/GuardianClient/GuardianClient.Tests/SearchAsyncTests.cs
+++ b/GuardianClient/GuardianClient.Tests/SearchAsyncTests.cs
@@ -9,22 +9,22 @@ public class SearchAsyncTests : TestBase
     [TestMethod]
     public async Task SearchAsync_WithQuery_ReturnsResults()
     {
-        var result = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var result = await Client.SearchAsync(new SearchOptions
         {
             Query = "climate change",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 5 }
+            PageOptions = new PageOptions { PageSize = 5 }
         });
 
-        result.ShouldNotBeNull("Search result should not be null");
-        result.Status.ShouldBe("ok", "API response status should be 'ok'");
-        result.Results.Count.ShouldBeGreaterThan(0, "Should return at least one result");
-        result.Results.Count.ShouldBeLessThanOrEqualTo(5, "Should not return more than requested page size");
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe("ok");
+        result.Results.Count.ShouldBeGreaterThan(0);
+        result.Results.Count.ShouldBeLessThanOrEqualTo(5);
 
         var firstItem = result.Results.First();
-        firstItem.Id.ShouldNotBeNullOrEmpty("Content item should have an ID");
-        firstItem.WebTitle.ShouldNotBeNullOrEmpty("Content item should have a title");
-        firstItem.WebUrl.ShouldNotBeNullOrEmpty("Content item should have a web URL");
-        firstItem.ApiUrl.ShouldNotBeNullOrEmpty("Content item should have an API URL");
+        firstItem.Id.ShouldNotBeNullOrEmpty();
+        firstItem.WebTitle.ShouldNotBeNullOrEmpty();
+        firstItem.WebUrl.ShouldNotBeNullOrEmpty();
+        firstItem.ApiUrl.ShouldNotBeNullOrEmpty();
 
         Console.WriteLine($"Found {result.Results.Count} articles about climate change");
         Console.WriteLine($"First article: {firstItem.WebTitle}");
@@ -34,25 +34,25 @@ public class SearchAsyncTests : TestBase
     [TestMethod]
     public async Task SearchAsync_WithNonExistentQuery_ReturnsNoResults()
     {
-        var result = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var result = await Client.SearchAsync(new SearchOptions
         {
             Query = "xyzabc123nonexistentquery456"
         });
 
-        result.ShouldNotBeNull("Search result should not be null even with no matches");
-        result.Status.ShouldBe("ok", "API response status should be 'ok'");
-        result.Results.Count.ShouldBe(0, "Should return zero results for non-existent query");
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe("ok");
+        result.Results.Count.ShouldBe(0);
     }
 
     [TestMethod]
     public async Task SearchAsync_WithNoOptions_ReturnsDefaultResults()
     {
-        var result = await ApiClient.SearchAsync();
+        var result = await Client.SearchAsync();
 
-        result.ShouldNotBeNull("Search result should not be null");
-        result.Status.ShouldBe("ok", "API response status should be 'ok'");
-        result.Results.Count.ShouldBeGreaterThan(0, "Should return results with default options");
-        result.Results.Count.ShouldBeLessThanOrEqualTo(10, "Default page size should be 10 or less");
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe("ok");
+        result.Results.Count.ShouldBeGreaterThan(0);
+        result.Results.Count.ShouldBeLessThanOrEqualTo(10);
 
         Console.WriteLine($"Default search returned {result.Results.Count} results");
     }
@@ -60,24 +60,24 @@ public class SearchAsyncTests : TestBase
     [TestMethod]
     public async Task SearchAsync_WithFilterOptions_ReturnsFilteredResults()
     {
-        var result = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var result = await Client.SearchAsync(new SearchOptions
         {
             Query = "technology",
-            FilterOptions = new GuardianApiContentFilterOptions
+            FilterOptions = new FilterOptions
             {
                 Section = "technology"
             },
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 3 }
+            PageOptions = new PageOptions { PageSize = 3 }
         });
 
-        result.ShouldNotBeNull("Search result should not be null");
-        result.Status.ShouldBe("ok", "API response status should be 'ok'");
-        result.Results.Count.ShouldBeGreaterThan(0, "Should return technology results");
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe("ok");
+        result.Results.Count.ShouldBeGreaterThan(0);
 
         // Check that results are from technology section
         foreach (var item in result.Results)
         {
-            item.SectionId.ShouldBe("technology", "All results should be from technology section");
+            item.SectionId.ShouldBe("technology");
         }
 
         Console.WriteLine($"Found {result.Results.Count} technology articles");
@@ -86,19 +86,19 @@ public class SearchAsyncTests : TestBase
     [TestMethod]
     public async Task SearchAsync_WithOrderOptions_ReturnsOrderedResults()
     {
-        var result = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var result = await Client.SearchAsync(new SearchOptions
         {
             Query = "sports",
-            OrderOptions = new GuardianApiContentOrderOptions
+            OrderOptions = new OrderOptions
             {
-                OrderBy = GuardianApiContentOrderBy.Oldest
+                OrderBy = ContentOrder.Oldest
             },
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 2 }
+            PageOptions = new PageOptions { PageSize = 2 }
         });
 
-        result.ShouldNotBeNull("Search result should not be null");
-        result.Status.ShouldBe("ok", "API response status should be 'ok'");
-        result.Results.Count.ShouldBeGreaterThan(0, "Should return sports results");
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe("ok");
+        result.Results.Count.ShouldBeGreaterThan(0);
 
         // Oldest first means first result should be older than or equal to second
         if (result.Results.Count >= 2)
@@ -108,8 +108,7 @@ public class SearchAsyncTests : TestBase
 
             if (first.WebPublicationDate.HasValue && second.WebPublicationDate.HasValue)
             {
-                first.WebPublicationDate.Value.ShouldBeLessThanOrEqualTo(second.WebPublicationDate.Value,
-                    "Results should be ordered oldest first");
+                first.WebPublicationDate.Value.ShouldBeLessThanOrEqualTo(second.WebPublicationDate.Value);
             }
         }
 
@@ -119,24 +118,25 @@ public class SearchAsyncTests : TestBase
     [TestMethod]
     public async Task SearchAsync_WithAdditionalInformation_ReturnsEnhancedResults()
     {
-        var result = await ApiClient.SearchAsync(new GuardianApiContentSearchOptions
+        var result = await Client.SearchAsync(new SearchOptions
         {
             Query = "environment",
-            PageOptions = new GuardianApiContentPageOptions { PageSize = 2 },
-            AdditionalInformationOptions = new GuardianApiContentAdditionalInformationOptions
+            PageOptions = new PageOptions { PageSize = 2 },
+            AdditionalInformationOptions = new AdditionalInformationOptions
             {
-                ShowFields = [GuardianApiContentShowFieldsOption.Headline, GuardianApiContentShowFieldsOption.Thumbnail],
-                ShowTags = [GuardianApiContentShowTagsOption.Keyword, GuardianApiContentShowTagsOption.Tone]
+                ShowFields =
+                    [ContentField.Headline, ContentField.Thumbnail],
+                ShowTags = [ContentTag.Keyword, ContentTag.Tone]
             }
         });
 
-        result.ShouldNotBeNull("Search result should not be null");
-        result.Status.ShouldBe("ok", "API response status should be 'ok'");
-        result.Results.Count.ShouldBeGreaterThan(0, "Should return environment results");
+        result.ShouldNotBeNull();
+        result.Status.ShouldBe("ok");
+        result.Results.Count.ShouldBeGreaterThan(0);
 
         var firstItem = result.Results.First();
-        firstItem.Fields.ShouldNotBeNull("Fields should be populated");
-        firstItem.Tags.ShouldNotBeNull("Tags should be populated");
+        firstItem.Fields.ShouldNotBeNull();
+        firstItem.Tags.ShouldNotBeNull();
 
         Console.WriteLine($"Enhanced search returned {result.Results.Count} environment articles");
         Console.WriteLine($"First article has {firstItem.Tags.Count} tags");

--- a/GuardianClient/GuardianClient.Tests/TestBase.cs
+++ b/GuardianClient/GuardianClient.Tests/TestBase.cs
@@ -6,7 +6,7 @@ namespace GuardianClient.Tests;
 
 public abstract class TestBase
 {
-    protected static IGuardianApiClient ApiClient { get; }
+    protected static IGuardianApiClient Client { get; }
 
     static TestBase()
     {
@@ -16,7 +16,7 @@ public abstract class TestBase
 
         var apiKey = config["GuardianApiKey"]!;
 
-        ApiClient = new ServiceCollection()
+        Client = new ServiceCollection()
             .AddGuardianApiClient(apiKey)
             .BuildServiceProvider()
             .GetRequiredService<GuardianApiClient>();

--- a/GuardianClient/GuardianClient/GuardianApiClient.cs
+++ b/GuardianClient/GuardianClient/GuardianApiClient.cs
@@ -53,11 +53,11 @@ public class GuardianApiClient : IGuardianApiClient, IDisposable
     }
 
     public async Task<ContentSearchResponse?> SearchAsync(
-        GuardianApiContentSearchOptions? options = null,
+        SearchOptions? options = null,
         CancellationToken cancellationToken = default
     )
     {
-        options ??= new GuardianApiContentSearchOptions();
+        options ??= new SearchOptions();
 
         var parameters = new List<string> { $"api-key={Uri.EscapeDataString(_apiKey)}" };
 
@@ -81,7 +81,7 @@ public class GuardianApiClient : IGuardianApiClient, IDisposable
 
     public async Task<SingleItemResponse?> GetItemAsync(
         string itemId,
-        GuardianApiContentAdditionalInformationOptions? options = null,
+        AdditionalInformationOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(itemId);

--- a/GuardianClient/GuardianClient/GuardianApiClient.cs
+++ b/GuardianClient/GuardianClient/GuardianApiClient.cs
@@ -52,6 +52,14 @@ public class GuardianApiClient : IGuardianApiClient, IDisposable
         ConfigureHttpClient();
     }
 
+    private void ConfigureHttpClient()
+    {
+        var packageVersion = AssemblyInfo.GetPackageVersion();
+
+        _httpClient.BaseAddress = new Uri(BaseUrl);
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", $"GuardianClient.NET/{packageVersion}");
+    }
+
     public async Task<ContentSearchResponse?> SearchAsync(
         SearchOptions? options = null,
         CancellationToken cancellationToken = default
@@ -135,14 +143,6 @@ public class GuardianApiClient : IGuardianApiClient, IDisposable
     {
         Dispose(true);
         GC.SuppressFinalize(this);
-    }
-
-    private void ConfigureHttpClient()
-    {
-        var packageVersion = AssemblyInfo.GetPackageVersion();
-
-        _httpClient.BaseAddress = new Uri(BaseUrl);
-        _httpClient.DefaultRequestHeaders.Add("User-Agent", $"GuardianClient.NET/{packageVersion}");
     }
 
     /// <summary>

--- a/GuardianClient/GuardianClient/GuardianApiClient.cs
+++ b/GuardianClient/GuardianClient/GuardianApiClient.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using GuardianClient.Internal;
 using GuardianClient.Models;
@@ -77,6 +78,7 @@ public class GuardianApiClient : IGuardianApiClient, IDisposable
         UrlParameterBuilder.AddAdditionalInformationParameters(options.AdditionalInformationOptions, parameters);
 
         var url = $"/search?{string.Join("&", parameters)}";
+        DebugWriteLine($"Guardian API URL: {BaseUrl}{url}");
         var response = await _httpClient.GetAsync(url, cancellationToken);
 
         response.EnsureSuccessStatusCode();
@@ -109,12 +111,14 @@ public class GuardianApiClient : IGuardianApiClient, IDisposable
             options?.ShowTags,
             option => option.ToApiString()
         );
+
         UrlParameterBuilder.AddParameterIfAny(
             parameters,
             "show-elements",
             options?.ShowElements,
             option => option.ToApiString()
         );
+
         UrlParameterBuilder.AddParameterIfAny(
             parameters,
             "show-references",
@@ -129,6 +133,7 @@ public class GuardianApiClient : IGuardianApiClient, IDisposable
         );
 
         var url = $"/{itemId}?{string.Join("&", parameters)}";
+        DebugWriteLine($"Guardian API URL: {BaseUrl}{url}");
         var response = await _httpClient.GetAsync(url, cancellationToken);
 
         response.EnsureSuccessStatusCode();
@@ -137,6 +142,12 @@ public class GuardianApiClient : IGuardianApiClient, IDisposable
         var wrapper = JsonSerializer.Deserialize<ResponseWrapper<SingleItemResponse>>(content, _JsonOptions);
 
         return wrapper?.Response;
+    }
+
+    [Conditional("DEBUG")]
+    private static void DebugWriteLine(string message)
+    {
+        Debug.WriteLine(message);
     }
 
     public void Dispose()

--- a/GuardianClient/GuardianClient/GuardianClient.csproj
+++ b/GuardianClient/GuardianClient/GuardianClient.csproj
@@ -7,13 +7,13 @@
 
     <!-- NuGet Package Properties -->
     <PackageId>GuardianClient.NET</PackageId>
-    <Version>0.4.0-alpha</Version>
+    <Version>0.5.0-alpha</Version>
     <Authors>Andrew Tarr</Authors>
     <Description>A .NET API wrapper for Guardian services</Description>
     <PackageTags>guardian;api;client;wrapper</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/tarrball/GuardianClient.NET</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/tarrball/GuardianClient.NET</RepositoryUrl>
+    <RepositoryUrl>https://github.com/tarrball/GuardianClient.NET.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>main</RepositoryBranch>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/GuardianClient/GuardianClient/IGuardianApiClient.cs
+++ b/GuardianClient/GuardianClient/IGuardianApiClient.cs
@@ -34,7 +34,7 @@ public interface IGuardianApiClient
     /// <para>For simple searches, you can create basic options: <c>new GuardianApiContentSearchOptions { Query = "your search terms" }</c></para>
     /// </remarks>
     Task<ContentSearchResponse?> SearchAsync(
-        GuardianApiContentSearchOptions? options = null,
+        SearchOptions? options = null,
         CancellationToken cancellationToken = default
     );
 
@@ -47,7 +47,7 @@ public interface IGuardianApiClient
     /// <returns>Single item response with content details</returns>
     Task<SingleItemResponse?> GetItemAsync(
         string itemId,
-        GuardianApiContentAdditionalInformationOptions? options = null,
+        AdditionalInformationOptions? options = null,
         CancellationToken cancellationToken = default
     );
 }

--- a/GuardianClient/GuardianClient/Internal/AdditionalInformationExtensions.cs
+++ b/GuardianClient/GuardianClient/Internal/AdditionalInformationExtensions.cs
@@ -7,89 +7,89 @@ namespace GuardianClient.Internal;
 /// </summary>
 internal static class AdditionalInformationExtensions
 {
-    internal static string ToApiString(this GuardianApiContentShowFieldsOption option) => option switch
+    internal static string ToApiString(this ContentField option) => option switch
     {
-        GuardianApiContentShowFieldsOption.TrailText => "trailText",
-        GuardianApiContentShowFieldsOption.Headline => "headline",
-        GuardianApiContentShowFieldsOption.ShowInRelatedContent => "showInRelatedContent",
-        GuardianApiContentShowFieldsOption.Body => "body",
-        GuardianApiContentShowFieldsOption.LastModified => "lastModified",
-        GuardianApiContentShowFieldsOption.HasStoryPackage => "hasStoryPackage",
-        GuardianApiContentShowFieldsOption.Score => "score",
-        GuardianApiContentShowFieldsOption.Standfirst => "standfirst",
-        GuardianApiContentShowFieldsOption.ShortUrl => "shortUrl",
-        GuardianApiContentShowFieldsOption.Thumbnail => "thumbnail",
-        GuardianApiContentShowFieldsOption.Wordcount => "wordcount",
-        GuardianApiContentShowFieldsOption.Commentable => "commentable",
-        GuardianApiContentShowFieldsOption.IsPremoderated => "isPremoderated",
-        GuardianApiContentShowFieldsOption.AllowUgc => "allowUgc",
-        GuardianApiContentShowFieldsOption.Byline => "byline",
-        GuardianApiContentShowFieldsOption.Publication => "publication",
-        GuardianApiContentShowFieldsOption.InternalPageCode => "internalPageCode",
-        GuardianApiContentShowFieldsOption.ProductionOffice => "productionOffice",
-        GuardianApiContentShowFieldsOption.ShouldHideAdverts => "shouldHideAdverts",
-        GuardianApiContentShowFieldsOption.LiveBloggingNow => "liveBloggingNow",
-        GuardianApiContentShowFieldsOption.CommentCloseDate => "commentCloseDate",
-        GuardianApiContentShowFieldsOption.StarRating => "starRating",
-        GuardianApiContentShowFieldsOption.All => "all",
+        ContentField.TrailText => "trailText",
+        ContentField.Headline => "headline",
+        ContentField.ShowInRelatedContent => "showInRelatedContent",
+        ContentField.Body => "body",
+        ContentField.LastModified => "lastModified",
+        ContentField.HasStoryPackage => "hasStoryPackage",
+        ContentField.Score => "score",
+        ContentField.Standfirst => "standfirst",
+        ContentField.ShortUrl => "shortUrl",
+        ContentField.Thumbnail => "thumbnail",
+        ContentField.Wordcount => "wordcount",
+        ContentField.Commentable => "commentable",
+        ContentField.IsPremoderated => "isPremoderated",
+        ContentField.AllowUgc => "allowUgc",
+        ContentField.Byline => "byline",
+        ContentField.Publication => "publication",
+        ContentField.InternalPageCode => "internalPageCode",
+        ContentField.ProductionOffice => "productionOffice",
+        ContentField.ShouldHideAdverts => "shouldHideAdverts",
+        ContentField.LiveBloggingNow => "liveBloggingNow",
+        ContentField.CommentCloseDate => "commentCloseDate",
+        ContentField.StarRating => "starRating",
+        ContentField.All => "all",
         _ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
     };
 
-    internal static string ToApiString(this GuardianApiContentShowTagsOption option) => option switch
+    internal static string ToApiString(this ContentTag option) => option switch
     {
-        GuardianApiContentShowTagsOption.Blog => "blog",
-        GuardianApiContentShowTagsOption.Contributor => "contributor",
-        GuardianApiContentShowTagsOption.Keyword => "keyword",
-        GuardianApiContentShowTagsOption.NewspaperBook => "newspaper-book",
-        GuardianApiContentShowTagsOption.NewspaperBookSection => "newspaper-book-section",
-        GuardianApiContentShowTagsOption.Publication => "publication",
-        GuardianApiContentShowTagsOption.Series => "series",
-        GuardianApiContentShowTagsOption.Tone => "tone",
-        GuardianApiContentShowTagsOption.Type => "type",
-        GuardianApiContentShowTagsOption.All => "all",
+        ContentTag.Blog => "blog",
+        ContentTag.Contributor => "contributor",
+        ContentTag.Keyword => "keyword",
+        ContentTag.NewspaperBook => "newspaper-book",
+        ContentTag.NewspaperBookSection => "newspaper-book-section",
+        ContentTag.Publication => "publication",
+        ContentTag.Series => "series",
+        ContentTag.Tone => "tone",
+        ContentTag.Type => "type",
+        ContentTag.All => "all",
         _ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
     };
 
-    internal static string ToApiString(this GuardianApiContentShowElementsOption option) => option switch
+    internal static string ToApiString(this ContentElement option) => option switch
     {
-        GuardianApiContentShowElementsOption.Audio => "audio",
-        GuardianApiContentShowElementsOption.Image => "image",
-        GuardianApiContentShowElementsOption.Video => "video",
-        GuardianApiContentShowElementsOption.All => "all",
+        ContentElement.Audio => "audio",
+        ContentElement.Image => "image",
+        ContentElement.Video => "video",
+        ContentElement.All => "all",
         _ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
     };
 
-    internal static string ToApiString(this GuardianApiContentShowReferencesOption option) => option switch
+    internal static string ToApiString(this Reference option) => option switch
     {
-        GuardianApiContentShowReferencesOption.Author => "author",
-        GuardianApiContentShowReferencesOption.BisacPrefix => "bisac-prefix",
-        GuardianApiContentShowReferencesOption.EsaCricketMatch => "esa-cricket-match",
-        GuardianApiContentShowReferencesOption.EsaFootballMatch => "esa-football-match",
-        GuardianApiContentShowReferencesOption.EsaFootballTeam => "esa-football-team",
-        GuardianApiContentShowReferencesOption.EsaFootballTournament => "esa-football-tournament",
-        GuardianApiContentShowReferencesOption.Isbn => "isbn",
-        GuardianApiContentShowReferencesOption.Imdb => "imdb",
-        GuardianApiContentShowReferencesOption.Musicbrainz => "musicbrainz",
-        GuardianApiContentShowReferencesOption.MusicbrainzGenre => "musicbrainzgenre",
-        GuardianApiContentShowReferencesOption.OptaCricketMatch => "opta-cricket-match",
-        GuardianApiContentShowReferencesOption.OptaFootballMatch => "opta-football-match",
-        GuardianApiContentShowReferencesOption.OptaFootballTeam => "opta-football-team",
-        GuardianApiContentShowReferencesOption.OptaFootballTournament => "opta-football-tournament",
-        GuardianApiContentShowReferencesOption.PaFootballCompetition => "pa-football-competition",
-        GuardianApiContentShowReferencesOption.PaFootballMatch => "pa-football-match",
-        GuardianApiContentShowReferencesOption.PaFootballTeam => "pa-football-team",
-        GuardianApiContentShowReferencesOption.R1Film => "r1-film",
-        GuardianApiContentShowReferencesOption.ReutersIndexRic => "reuters-index-ric",
-        GuardianApiContentShowReferencesOption.ReutersStockRic => "reuters-stock-ric",
-        GuardianApiContentShowReferencesOption.WitnessAssignment => "witness-assignment",
+        Reference.Author => "author",
+        Reference.BisacPrefix => "bisac-prefix",
+        Reference.EsaCricketMatch => "esa-cricket-match",
+        Reference.EsaFootballMatch => "esa-football-match",
+        Reference.EsaFootballTeam => "esa-football-team",
+        Reference.EsaFootballTournament => "esa-football-tournament",
+        Reference.Isbn => "isbn",
+        Reference.Imdb => "imdb",
+        Reference.Musicbrainz => "musicbrainz",
+        Reference.MusicbrainzGenre => "musicbrainzgenre",
+        Reference.OptaCricketMatch => "opta-cricket-match",
+        Reference.OptaFootballMatch => "opta-football-match",
+        Reference.OptaFootballTeam => "opta-football-team",
+        Reference.OptaFootballTournament => "opta-football-tournament",
+        Reference.PaFootballCompetition => "pa-football-competition",
+        Reference.PaFootballMatch => "pa-football-match",
+        Reference.PaFootballTeam => "pa-football-team",
+        Reference.R1Film => "r1-film",
+        Reference.ReutersIndexRic => "reuters-index-ric",
+        Reference.ReutersStockRic => "reuters-stock-ric",
+        Reference.WitnessAssignment => "witness-assignment",
         _ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
     };
 
-    internal static string ToApiString(this GuardianApiContentShowRightsOption option) => option switch
+    internal static string ToApiString(this ContentRight option) => option switch
     {
-        GuardianApiContentShowRightsOption.Syndicatable => "syndicatable",
-        GuardianApiContentShowRightsOption.SubscriptionDatabases => "subscription-databases",
-        GuardianApiContentShowRightsOption.All => "all",
+        ContentRight.Syndicatable => "syndicatable",
+        ContentRight.SubscriptionDatabases => "subscription-databases",
+        ContentRight.All => "all",
         _ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
     };
 }

--- a/GuardianClient/GuardianClient/Internal/UrlParameterBuilder.cs
+++ b/GuardianClient/GuardianClient/Internal/UrlParameterBuilder.cs
@@ -36,13 +36,13 @@ internal static class UrlParameterBuilder
         }
     }
 
-    internal static void AddQueryParameters(GuardianApiContentSearchOptions options, List<string> parameters)
+    internal static void AddQueryParameters(SearchOptions options, List<string> parameters)
     {
         AddParameterIfNotEmpty(parameters, "q", options.Query);
         AddParameterIfAny(parameters, "query-fields", options.QueryFields);
     }
 
-    internal static void AddFilterParameters(GuardianApiContentFilterOptions filterOptions, List<string> parameters)
+    internal static void AddFilterParameters(FilterOptions filterOptions, List<string> parameters)
     {
         AddParameterIfNotEmpty(parameters, "section", filterOptions.Section);
         AddParameterIfNotEmpty(parameters, "reference", filterOptions.Reference);
@@ -56,7 +56,7 @@ internal static class UrlParameterBuilder
         AddParameterIfHasValue(parameters, "star-rating", filterOptions.StarRating);
     }
 
-    internal static void AddDateParameters(GuardianApiContentDateOptions dateOptions, List<string> parameters)
+    internal static void AddDateParameters(DateOptions dateOptions, List<string> parameters)
     {
         if (dateOptions.FromDate != default)
         {
@@ -71,7 +71,7 @@ internal static class UrlParameterBuilder
         AddParameterIfNotEmpty(parameters, "use-date", dateOptions.UseDate);
     }
 
-    internal static void AddPageParameters(GuardianApiContentPageOptions pageOptions, List<string> parameters)
+    internal static void AddPageParameters(PageOptions pageOptions, List<string> parameters)
     {
         if (pageOptions.Page > 0)
         {
@@ -84,15 +84,15 @@ internal static class UrlParameterBuilder
         }
     }
 
-    internal static void AddOrderParameters(GuardianApiContentOrderOptions orderOptions, List<string> parameters)
+    internal static void AddOrderParameters(OrderOptions orderOptions, List<string> parameters)
     {
         if (orderOptions.OrderBy.HasValue)
         {
             var orderByValue = orderOptions.OrderBy.Value switch
             {
-                GuardianApiContentOrderBy.Newest => "newest",
-                GuardianApiContentOrderBy.Oldest => "oldest",
-                GuardianApiContentOrderBy.Relevance => "relevance",
+                ContentOrder.Newest => "newest",
+                ContentOrder.Oldest => "oldest",
+                ContentOrder.Relevance => "relevance",
                 _ => "newest"
             };
             parameters.Add($"order-by={orderByValue}");
@@ -102,9 +102,9 @@ internal static class UrlParameterBuilder
         {
             var orderDateValue = orderOptions.OrderDate.Value switch
             {
-                GuardianApiContentOrderDate.Published => "published",
-                GuardianApiContentOrderDate.NewspaperEdition => "newspaper-edition",
-                GuardianApiContentOrderDate.LastModified => "last-modified",
+                ContentType.Published => "published",
+                ContentType.NewspaperEdition => "newspaper-edition",
+                ContentType.LastModified => "last-modified",
                 _ => "published"
             };
             parameters.Add($"order-date={orderDateValue}");
@@ -112,7 +112,7 @@ internal static class UrlParameterBuilder
     }
 
     internal static void AddAdditionalInformationParameters(
-        GuardianApiContentAdditionalInformationOptions additionalOptions,
+        AdditionalInformationOptions additionalOptions,
         List<string> parameters
     )
     {

--- a/GuardianClient/GuardianClient/Internal/UrlParameterBuilder.cs
+++ b/GuardianClient/GuardianClient/Internal/UrlParameterBuilder.cs
@@ -120,6 +120,7 @@ internal static class UrlParameterBuilder
         AddParameterIfAny(parameters, "show-tags", additionalOptions.ShowTags, t => t.ToApiString());
         AddParameterIfAny(parameters, "show-elements", additionalOptions.ShowElements, e => e.ToApiString());
         AddParameterIfAny(parameters, "show-references", additionalOptions.ShowReferences, r => r.ToApiString());
+        AddParameterIfAny(parameters, "show-rights", additionalOptions.ShowRights, r => r.ToApiString());
         AddParameterIfAny(parameters, "show-blocks", additionalOptions.ShowBlocks);
     }
 }

--- a/GuardianClient/GuardianClient/Options/Search/AdditionalInformationOptions.cs
+++ b/GuardianClient/GuardianClient/Options/Search/AdditionalInformationOptions.cs
@@ -6,27 +6,27 @@ namespace GuardianClient.Options.Search;
 /// Options for requesting additional information to be included with search results.
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-public class GuardianApiContentAdditionalInformationOptions
+public class AdditionalInformationOptions
 {
     /// <summary>
     /// Add fields associated with the content such as headline, body, thumbnail, etc.
     /// </summary>
-    public GuardianApiContentShowFieldsOption[]? ShowFields { get; set; }
+    public ContentField[]? ShowFields { get; set; }
 
     /// <summary>
     /// Add associated metadata tags such as contributor, keyword, tone, etc.
     /// </summary>
-    public GuardianApiContentShowTagsOption[]? ShowTags { get; set; }
+    public ContentTag[]? ShowTags { get; set; }
 
     /// <summary>
     /// Add associated media elements such as images, audio, and video.
     /// </summary>
-    public GuardianApiContentShowElementsOption[]? ShowElements { get; set; }
+    public ContentElement[]? ShowElements { get; set; }
 
     /// <summary>
     /// Add associated reference data such as ISBNs, IMDB IDs, author references, etc.
     /// </summary>
-    public GuardianApiContentShowReferencesOption[]? ShowReferences { get; set; }
+    public Reference[]? ShowReferences { get; set; }
 
 
     /// <summary>

--- a/GuardianClient/GuardianClient/Options/Search/AdditionalInformationOptions.cs
+++ b/GuardianClient/GuardianClient/Options/Search/AdditionalInformationOptions.cs
@@ -28,6 +28,10 @@ public class AdditionalInformationOptions
     /// </summary>
     public Reference[]? ShowReferences { get; set; }
 
+    /// <summary>
+    /// Add associated rights information such as syndicatable or subscription-databases.
+    /// </summary>
+    public ContentRight[]? ShowRights { get; set; }
 
     /// <summary>
     /// Add associated blocks (single block for content, one or more for liveblogs).

--- a/GuardianClient/GuardianClient/Options/Search/ContentElement.cs
+++ b/GuardianClient/GuardianClient/Options/Search/ContentElement.cs
@@ -3,7 +3,7 @@ namespace GuardianClient.Options.Search;
 /// <summary>
 /// Media element types that can be included with content responses.
 /// </summary>
-public enum GuardianApiContentShowElementsOption
+public enum ContentElement
 {
     Audio,
     Image,

--- a/GuardianClient/GuardianClient/Options/Search/ContentField.cs
+++ b/GuardianClient/GuardianClient/Options/Search/ContentField.cs
@@ -3,7 +3,7 @@ namespace GuardianClient.Options.Search;
 /// <summary>
 /// Fields that can be included with content responses.
 /// </summary>
-public enum GuardianApiContentShowFieldsOption
+public enum ContentField
 {
     TrailText,
     Headline,

--- a/GuardianClient/GuardianClient/Options/Search/ContentOrder.cs
+++ b/GuardianClient/GuardianClient/Options/Search/ContentOrder.cs
@@ -3,7 +3,7 @@ namespace GuardianClient.Options.Search;
 /// <summary>
 /// Specifies the order in which search results should be returned.
 /// </summary>
-public enum GuardianApiContentOrderBy
+public enum ContentOrder
 {
     /// <summary>
     /// Order by newest content first. Default in all other cases.

--- a/GuardianClient/GuardianClient/Options/Search/ContentReference.cs
+++ b/GuardianClient/GuardianClient/Options/Search/ContentReference.cs
@@ -3,7 +3,7 @@ namespace GuardianClient.Options.Search;
 /// <summary>
 /// Reference types that can be included with content responses.
 /// </summary>
-public enum GuardianApiContentShowReferencesOption
+public enum Reference
 {
     Author,
     BisacPrefix,

--- a/GuardianClient/GuardianClient/Options/Search/ContentRight.cs
+++ b/GuardianClient/GuardianClient/Options/Search/ContentRight.cs
@@ -3,7 +3,7 @@ namespace GuardianClient.Options.Search;
 /// <summary>
 /// Rights types that can be included with content responses.
 /// </summary>
-public enum GuardianApiContentShowRightsOption
+public enum ContentRight
 {
     Syndicatable,
     SubscriptionDatabases,

--- a/GuardianClient/GuardianClient/Options/Search/ContentTag.cs
+++ b/GuardianClient/GuardianClient/Options/Search/ContentTag.cs
@@ -3,7 +3,7 @@ namespace GuardianClient.Options.Search;
 /// <summary>
 /// Tag types that can be included with content responses.
 /// </summary>
-public enum GuardianApiContentShowTagsOption
+public enum ContentTag
 {
     Blog,
     Contributor,

--- a/GuardianClient/GuardianClient/Options/Search/ContentType.cs
+++ b/GuardianClient/GuardianClient/Options/Search/ContentType.cs
@@ -3,7 +3,7 @@ namespace GuardianClient.Options.Search;
 /// <summary>
 /// Specifies which type of date is used to order the results.
 /// </summary>
-public enum GuardianApiContentOrderDate
+public enum ContentType
 {
     /// <summary>
     /// The date the content appeared on the web. Default.

--- a/GuardianClient/GuardianClient/Options/Search/DateOptions.cs
+++ b/GuardianClient/GuardianClient/Options/Search/DateOptions.cs
@@ -3,7 +3,7 @@ namespace GuardianClient.Options.Search;
 /// <summary>
 /// Options for filtering search results by date ranges.
 /// </summary>
-public class GuardianApiContentDateOptions
+public class DateOptions
 {
     /// <summary>
     /// Return only content published on or after that date.

--- a/GuardianClient/GuardianClient/Options/Search/FilterOptions.cs
+++ b/GuardianClient/GuardianClient/Options/Search/FilterOptions.cs
@@ -6,7 +6,7 @@ namespace GuardianClient.Options.Search;
 /// Options for filtering content search results by various criteria.
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-public class GuardianApiContentFilterOptions
+public class FilterOptions
 {
     /// <summary>
     /// Return only content in those sections. Supports boolean operators.

--- a/GuardianClient/GuardianClient/Options/Search/OrderOptions.cs
+++ b/GuardianClient/GuardianClient/Options/Search/OrderOptions.cs
@@ -6,15 +6,15 @@ namespace GuardianClient.Options.Search;
 /// Options for controlling the ordering of search results.
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-public class GuardianApiContentOrderOptions
+public class OrderOptions
 {
     /// <summary>
     /// Returns results in the specified order. Defaults to Newest in most cases, or Relevance when a query parameter is specified.
     /// </summary>
-    public GuardianApiContentOrderBy? OrderBy { get; set; }
+    public ContentOrder? OrderBy { get; set; }
 
     /// <summary>
     /// Changes which type of date is used to order the results. Defaults to Published.
     /// </summary>
-    public GuardianApiContentOrderDate? OrderDate { get; set; }
+    public ContentType? OrderDate { get; set; }
 }

--- a/GuardianClient/GuardianClient/Options/Search/PageOptions.cs
+++ b/GuardianClient/GuardianClient/Options/Search/PageOptions.cs
@@ -6,7 +6,7 @@ namespace GuardianClient.Options.Search;
 /// Options for controlling pagination of search results.
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-public class GuardianApiContentPageOptions
+public class PageOptions
 {
     /// <summary>
     /// Return only the result set from a particular page.

--- a/GuardianClient/GuardianClient/Options/Search/SearchOptions.cs
+++ b/GuardianClient/GuardianClient/Options/Search/SearchOptions.cs
@@ -6,7 +6,7 @@ namespace GuardianClient.Options.Search;
 /// Options for searching content using the Guardian API.
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-public class GuardianApiContentSearchOptions
+public class SearchOptions
 {
     /// <summary>
     /// Request content containing this free text. Supports AND, OR and NOT operators, and exact phrase queries using double quotes.
@@ -23,25 +23,25 @@ public class GuardianApiContentSearchOptions
     /// <summary>
     /// Options for requesting additional information to be included with search results.
     /// </summary>
-    public GuardianApiContentAdditionalInformationOptions AdditionalInformationOptions { get; set; } = new();
+    public AdditionalInformationOptions AdditionalInformationOptions { get; set; } = new();
 
     /// <summary>
     /// Options for filtering search results by various criteria.
     /// </summary>
-    public GuardianApiContentFilterOptions FilterOptions { get; set; } = new();
+    public FilterOptions FilterOptions { get; set; } = new();
 
     /// <summary>
     /// Options for filtering search results by date ranges.
     /// </summary>
-    public GuardianApiContentDateOptions DateOptions { get; set; } = new();
+    public DateOptions DateOptions { get; set; } = new();
 
     /// <summary>
     /// Options for controlling pagination of search results.
     /// </summary>
-    public GuardianApiContentPageOptions PageOptions { get; set; } = new();
+    public PageOptions PageOptions { get; set; } = new();
 
     /// <summary>
     /// Options for controlling the ordering of search results.
     /// </summary>
-    public GuardianApiContentOrderOptions OrderOptions { get; set; } = new();
+    public OrderOptions OrderOptions { get; set; } = new();
 }


### PR DESCRIPTION
## Pull Request Overview

This PR implements a major API simplification by removing verbose "GuardianApi" prefixes from class and enum names, making the API more concise and user-friendly. The changes also introduce a previously missing `ShowRights` option and update the version to 0.5.0-alpha.

- Renamed all options classes to shorter names (e.g., `GuardianApiContentSearchOptions` → `SearchOptions`)
- Renamed all enums with cleaner names (e.g., `GuardianApiContentOrderBy` → `ContentOrder`)
- Added missing `ShowRights` functionality with `ContentRight` enum

### Reviewed Changes

Copilot reviewed 22 out of 22 changed files in this pull request and generated no comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| SearchOptions.cs | Renamed from GuardianApiContentSearchOptions and updated property types |
| PageOptions.cs | Renamed from GuardianApiContentPageOptions |
| OrderOptions.cs | Renamed class and property types to use new enum names |
| FilterOptions.cs | Renamed from GuardianApiContentFilterOptions |
| DateOptions.cs | Renamed from GuardianApiContentDateOptions |
| ContentType.cs | Renamed from GuardianApiContentOrderDate |
| ContentTag.cs | Renamed from GuardianApiContentShowTagsOption |
| ContentRight.cs | Renamed from GuardianApiContentShowRightsOption |
| ContentReference.cs | Renamed from GuardianApiContentShowReferencesOption to Reference |
| ContentOrder.cs | Renamed from GuardianApiContentOrderBy |
| ContentField.cs | Renamed from GuardianApiContentShowFieldsOption |
| ContentElement.cs | Renamed from GuardianApiContentShowElementsOption |
| AdditionalInformationOptions.cs | Renamed class and added missing ShowRights property |
| UrlParameterBuilder.cs | Updated method signatures and enum references to use new names |
| AdditionalInformationExtensions.cs | Updated extension methods to use new enum names |
| IGuardianApiClient.cs | Updated interface method signatures to use new option types |
| GuardianClient.csproj | Version bump and repository URL refinement |
| GuardianApiClient.cs | Updated method signatures, added debug logging, and code reorganization |
| TestBase.cs | Renamed ApiClient property to Client |
| SearchAsyncTests.cs | Updated to use new option class names and simplified assertions |
| GuardianApiClientIntegrationTests.cs | Updated to use new option class names and added new test method |
| GetItemAsyncTests.cs | Updated to use new option class names throughout test methods |
</details>






---

<sub>**Tip:** Customize your code reviews with copilot-instructions.md. <a href="/tarrball/GuardianClient.NET/new/main/.github?filename=copilot-instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Create the file</a> or <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">learn how to get started</a>.</sub>